### PR TITLE
fixes typo in usr/bin/nodeinfo that showed lon as a lat.

### DIFF
--- a/gluon-banner/files/usr/bin/nodeinfo
+++ b/gluon-banner/files/usr/bin/nodeinfo
@@ -37,6 +37,6 @@ echo "### BatGateways"
 batctl gwl
 echo -n "### Location: Geo?:$(uci show|grep .share_location=|cut -d= -f2)"
 echo -n " lon:$(uci show|grep .longitude=|cut -d= -f2)"
-echo -n " lat:$(uci show|grep .longitude=|cut -d= -f2)"
+echo -n " lat:$(uci show|grep .latitude=|cut -d= -f2)"
 echo -n " Contact:$(uci show|grep contact|cut -d= -f2)"
 echo .


### PR DESCRIPTION
Here was a little c&p misstake I'd guess it was meant to be `latitude` in line 40.
I didn't test anything but I think it should do.